### PR TITLE
fix: Cookie有効期限を7日から1日に変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Phase 2 → Phase 3 では実装クラスを差し替えるだけで移行でき
 | 地図ライブラリ | MapLibre GL JS |
 | 位置情報バックエンド | AWS Location Service v2（Tracker + API キー） |
 | Hosting | Vercel (Hobby プラン) |
-| 認証 | 合言葉 + HttpOnly Cookie（7 日間） |
+| 認証 | 合言葉 + HttpOnly Cookie（1 日間） |
 | 状態管理 | localStorage（車両名・色のみ） |
 | CI | GitHub Actions（lint + 型チェック + ビルド確認） |
 | CD | GitHub Actions → Vercel CLI |

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -2,14 +2,14 @@
 import { NextRequest, NextResponse } from "next/server";
 
 const COOKIE_NAME = "is_authed";
-const SEVEN_DAYS_SEC = 60 * 60 * 24 * 7;
+const ONE_DAY_SEC = 60 * 60 * 24;
 
 export function setAuthCookie(res: NextResponse): void {
   res.cookies.set(COOKIE_NAME, process.env.AUTH_TOKEN!, {
     httpOnly: true,
     secure: true,
     sameSite: "strict",
-    maxAge: SEVEN_DAYS_SEC,
+    maxAge: ONE_DAY_SEC,
     path: "/",
   });
 }


### PR DESCRIPTION
## Summary
- 合言葉認証のCookie `maxAge` を 7日（604800秒）→ 1日（86400秒）に短縮
- `lib/auth.ts` の定数名を `SEVEN_DAYS_SEC` → `ONE_DAY_SEC` に変更
- `README.md` の技術スタック表記を「7 日間」→「1 日間」に更新

Closes #1

## Test plan
- [ ] `/auth` で合言葉を入力してログイン
- [ ] DevTools → Application → Cookies で `is_authed` の Expires が約1日後になっていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)